### PR TITLE
Distinct keys for different account names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Change Log
 
+## 0.1.3 - 2025-05-25
+
+### Features
+
+- add support (initial) for scenario files in the dialler and receiver applications
+- allow distinct keys for different account names
+
 ## 0.1.2 - 2025-05-19
 
 ### Features
 
-- add UDP support to the dialer and receiver apps
+- add UDP support to the dialler and receiver apps
 
 ## 0.1.1 - 2025-05-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,8 @@ dependencies = [
  "hex",
  "nom",
  "rand",
+ "serde",
+ "serde_json",
  "thiserror 2.0.12",
  "time",
  "tracing-appender",
@@ -609,6 +611,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +634,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,12 +78,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -95,9 +95,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-padding"
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -202,7 +202,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "common"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes",
  "anyhow",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "dialler"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -409,13 +409,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -466,6 +466,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "overload"
@@ -549,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "receiver"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -775,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains `Dialler` and `Receiver` simulators for the `SIA DC-09`
 
 ### Overview
 
-The DC-09 Dialler Simulator is a command-line application designed to send DC-09 protocol messages to a specified receiver. The simulator supports repeating messages and customizing sequence numbers for testing scenarios.
+The DC-09 Dialler Simulator is a command-line application designed to send DC-09 protocol messages to a specified receiver. The simulator supports creating multiple diallers and repeating messages for testing scenarios.
 
 ### Features
 
@@ -14,6 +14,7 @@ The DC-09 Dialler Simulator is a command-line application designed to send DC-09
 - Configure message content, account number, and ID token.
 - Support for message repetition and sequence number customization.
 - Optional encryption with a user-provided key (16, 24, or 32 bytes).
+- Initial support for scenario files, currently limited to custom dialler names and keys.
 
 ### Usage
 
@@ -34,6 +35,7 @@ The application uses the following arguments, configurable via the command line:
 | `--repeat`, `-r`   | Number of times to repeat the message per dialler             | 1                             | --repeat 5                          |
 | `--key`, `-k`      | Encryption key for DC09 messages (16, 24, or 32 bytes)        | None                          | --key "my16bytekey1234567890abcdef" |
 | `--udp`, `-u`      | Use a UDP connection instead of a TCP one                     | false                         | --udp                               |
+| `--scenarios`      | Configuration file specifying defined scenarios for the run   | None                          | --scenarios examples/scenarios.json |
 
 #### Example commands
 
@@ -60,6 +62,7 @@ The DC-09 Receiver Simulator is a command-line test server that handles DC-09 di
 - Listens for incoming DC09 dialler connections.
 - Optional encryption with a user-provided key (16, 24, or 32 bytes).
 - Optional `NAK` response for received messages.
+- Assign distinct keys to different account names using scenario files.
 
 ### Usage
 
@@ -67,12 +70,13 @@ The DC-09 Receiver Simulator is a command-line test server that handles DC-09 di
 
 The application uses the following arguments, configurable via the command line:
 
-| Argument       | Description                                             | Default Value | Example                             |
-|:---------------|:--------------------------------------------------------|:--------------|:------------------------------------|
-| `--address`    | IP address to listen on                                 | 127.0.0.1     | --address 192.168.1.100             |
-| `--port`, `-p` | Port number to listen on                                | 8080          | --port 9000                         |
-| `--key`, `-k`  | Key to decrypt DC09 messages (16, 24, or 32 bytes long) | None          | --key "my16bytekey1234567890abcdef" |
-| `--nak`        | Send `NAK` instead of `ACK` for received messages       | false         | --nak                               |
+| Argument       | Description                                                 | Default Value | Example                             |
+|:---------------|:------------------------------------------------------------|:--------------|:------------------------------------|
+| `--address`    | IP address to listen on                                     | 127.0.0.1     | --address 192.168.1.100             |
+| `--port`, `-p` | Port number to listen on                                    | 8080          | --port 9000                         |
+| `--key`, `-k`  | Key to decrypt DC09 messages (16, 24, or 32 bytes long)     | None          | --key "my16bytekey1234567890abcdef" |
+| `--nak`        | Send `NAK` instead of `ACK` for received messages           | false         | --nak                               |
+| `--scenarios`  | Configuration file specifying defined scenarios for the run | None          | --scenarios examples/scenarios.json |
 
 #### Example commands
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,6 +11,8 @@ crc = { version = "3.2" }
 hex = { version = "0.4" }
 nom = { version = "8.0" }
 rand = { version = "0.9" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
 thiserror = { version = "2.0" }
 time = { version = "0.3", features = ["local-offset", "formatting", "macros"] }
 tracing-appender = { version = "0.2" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 
 [dependencies]

--- a/common/src/dc09/parser.rs
+++ b/common/src/dc09/parser.rs
@@ -42,6 +42,16 @@ pub enum DC09Error {
     InvalidAccountNumber,
 }
 
+/// Parses an account name from the DC09 message.  
+/// **Note** that this function does not validate CRC of the message.
+pub fn parse_dc09_account_name(input: &str) -> Result<String, DC09Error> {
+    let Ok((_, header)) = parse_dc09_header(input) else {
+        return Err(DC09Error::ParseHeaderError);
+    };
+
+    Ok(header.account.to_owned())
+}
+
 /// Parses a complete DC09 message.  
 /// Format example: `3BAC0029"SIA-DCS"0002#0123[#0123|Nti20:50:26RP99]`
 pub fn parse_dc09(input: &str, key: Option<&str>) -> Result<DC09Message, DC09Error> {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod dc09;
 pub mod logging;
+pub mod scenarios;
 pub mod utils;

--- a/common/src/scenarios.rs
+++ b/common/src/scenarios.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct DiallerConfig {
+    pub name: String,
+    pub key: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct Scenarios {
+    pub diallers: Vec<DiallerConfig>,
+}

--- a/common/src/scenarios.rs
+++ b/common/src/scenarios.rs
@@ -1,12 +1,31 @@
 use serde::{Deserialize, Serialize};
 
+use crate::utils::VALID_KEY_LENGTHS;
+
+/// Keeps dialler configuration.
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct DiallerConfig {
     pub name: String,
     pub key: Option<String>,
 }
 
+/// Stores dialer configurations and, in the future, will support test scenarios for them.
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct Scenarios {
     pub diallers: Vec<DiallerConfig>,
+}
+
+impl Scenarios {
+    /// Checks whether [`Scenarios`] contains valid and meaningful data.
+    pub fn validate(&self) -> Result<(), String> {
+        for dialler in &self.diallers {
+            if let Some(key) = &dialler.key {
+                if !VALID_KEY_LENGTHS.contains(&key.len()) {
+                    return Err(format!("{}: key length must be 16, 24 or 32 bytes", dialler.name));
+                }
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -2,7 +2,7 @@ use std::{fs::File, io::Read, path::Path};
 
 use crate::scenarios::Scenarios;
 
-const VALID_KEY_LENGTHS: [usize; 3] = [16, 24, 32];
+pub const VALID_KEY_LENGTHS: [usize; 3] = [16, 24, 32];
 
 /// Parses key and validates its length.
 pub fn parse_key(s: &str) -> Result<String, String> {
@@ -17,25 +17,20 @@ pub fn parse_key(s: &str) -> Result<String, String> {
 pub fn parse_scenarios_path(s: &str) -> Result<Scenarios, String> {
     let path = Path::new(s);
     if !path.exists() {
-        return Err("Provided file does not exist".to_owned());
+        return Err("The provided file does not exist".to_owned());
     }
 
     if let Ok(mut file) = File::open(path) {
         let mut scenarios_str = String::new();
         if file.read_to_string(&mut scenarios_str).is_ok() {
             if let Ok(scenarios) = serde_json::from_str::<Scenarios>(&scenarios_str) {
-                for dialler in &scenarios.diallers {
-                    if let Some(key) = &dialler.key {
-                        if !VALID_KEY_LENGTHS.contains(&key.len()) {
-                            return Err(format!("{}: key length must be 16, 24 or 32 bytes", dialler.name));
-                        }
-                    }
-                }
-
-                return Ok(scenarios);
+                return match scenarios.validate() {
+                    Ok(_) => Ok(scenarios),
+                    Err(e) => Err(e),
+                };
             }
         }
     }
 
-    Err("Cannot read provided file as Scenarios".to_owned())
+    Err("Unable to deserialize the provided file into a Scenarios object".to_owned())
 }

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -1,3 +1,7 @@
+use std::{fs::File, io::Read, path::Path};
+
+use crate::scenarios::Scenarios;
+
 const VALID_KEY_LENGTHS: [usize; 3] = [16, 24, 32];
 
 /// Parses key and validates its length.
@@ -7,4 +11,31 @@ pub fn parse_key(s: &str) -> Result<String, String> {
     } else {
         Err("Key length must be 16, 24 or 32 bytes".to_owned())
     }
+}
+
+/// Loads [`Scenarios`] from the provided file path.
+pub fn parse_scenarios_path(s: &str) -> Result<Scenarios, String> {
+    let path = Path::new(s);
+    if !path.exists() {
+        return Err("Provided file does not exist".to_owned());
+    }
+
+    if let Ok(mut file) = File::open(path) {
+        let mut scenarios_str = String::new();
+        if file.read_to_string(&mut scenarios_str).is_ok() {
+            if let Ok(scenarios) = serde_json::from_str::<Scenarios>(&scenarios_str) {
+                for dialler in &scenarios.diallers {
+                    if let Some(key) = &dialler.key {
+                        if !VALID_KEY_LENGTHS.contains(&key.len()) {
+                            return Err(format!("{}: key length must be 16, 24 or 32 bytes", dialler.name));
+                        }
+                    }
+                }
+
+                return Ok(scenarios);
+            }
+        }
+    }
+
+    Err("Cannot read provided file as Scenarios".to_owned())
 }

--- a/dialler/Cargo.toml
+++ b/dialler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dialler"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 
 [dependencies]

--- a/dialler/src/cli.rs
+++ b/dialler/src/cli.rs
@@ -53,7 +53,7 @@ pub struct Args {
     #[arg(long, short)]
     pub udp: bool,
 
-    /// File with defined scenarios for this run.
+    /// File with defined scenarios configuration for this run.
     #[arg(long, value_parser = parse_scenarios_path)]
     pub scenarios: Option<Scenarios>,
 }

--- a/dialler/src/cli.rs
+++ b/dialler/src/cli.rs
@@ -53,7 +53,7 @@ pub struct Args {
     #[arg(long, short)]
     pub udp: bool,
 
-    /// File with defined scenarios configuration for this run.
+    /// Configuration file specifying defined scenarios for the run.
     #[arg(long, value_parser = parse_scenarios_path)]
     pub scenarios: Option<Scenarios>,
 }

--- a/dialler/src/cli.rs
+++ b/dialler/src/cli.rs
@@ -1,5 +1,8 @@
 use clap::Parser;
-use common::utils::parse_key;
+use common::{
+    scenarios::Scenarios,
+    utils::{parse_key, parse_scenarios_path},
+};
 use std::net::IpAddr;
 
 /// Test client that sends DC09 messages.
@@ -11,7 +14,7 @@ pub struct Args {
     pub address: IpAddr,
 
     /// Port number of the receiver.
-    #[arg(long, short, default_value = "8080")]
+    #[arg(long, short, default_value_t = 8080)]
     pub port: u16,
 
     /// ID token.
@@ -31,15 +34,15 @@ pub struct Args {
     pub fixed: bool,
 
     /// Message sequence start number.
-    #[arg(long, short, default_value = "1")]
+    #[arg(long, short, default_value_t = 1)]
     pub sequence: u16,
 
     /// Number of diallers to create.
-    #[arg(long, short, default_value = "1")]
+    #[arg(long, short, default_value_t = 1)]
     pub diallers: u16,
 
     /// Repeat message the specified number of times per dialler.
-    #[arg(long, short, default_value = "1")]
+    #[arg(long, short, default_value_t = 1)]
     pub repeat: u16,
 
     /// Key to encrypt DC09 messages (16, 24 or 32 bytes long).
@@ -49,4 +52,8 @@ pub struct Args {
     /// Use a UDP connection instead of a TCP one.
     #[arg(long, short)]
     pub udp: bool,
+
+    /// File with defined scenarios for this run.
+    #[arg(long, value_parser = parse_scenarios_path)]
+    pub scenarios: Option<Scenarios>,
 }

--- a/examples/scenarios.json
+++ b/examples/scenarios.json
@@ -1,0 +1,16 @@
+{
+    "diallers": [
+        {
+            "name": "1234",
+            "key": null
+        },
+        {
+            "name": "1235",
+            "key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+            "name": "1236",
+            "key": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+    ]
+}

--- a/receiver/Cargo.toml
+++ b/receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "receiver"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 
 [dependencies]

--- a/receiver/src/cli.rs
+++ b/receiver/src/cli.rs
@@ -25,7 +25,7 @@ pub struct Args {
     #[arg(long)]
     pub nak: bool,
 
-    /// File with defined scenarios configuration for this run.
+    /// Configuration file specifying defined scenarios for the run.
     #[arg(long, value_parser = parse_scenarios_path)]
     pub scenarios: Option<Scenarios>,
 }

--- a/receiver/src/cli.rs
+++ b/receiver/src/cli.rs
@@ -1,5 +1,8 @@
 use clap::Parser;
-use common::utils::parse_key;
+use common::{
+    scenarios::Scenarios,
+    utils::{parse_key, parse_scenarios_path},
+};
 use std::net::IpAddr;
 
 /// Test server that handles DC09 dialler connections.
@@ -21,4 +24,8 @@ pub struct Args {
     /// Send `NAK` instead of `ACK` for received messages.
     #[arg(long)]
     pub nak: bool,
+
+    /// File with defined scenarios configuration for this run.
+    #[arg(long, value_parser = parse_scenarios_path)]
+    pub scenarios: Option<Scenarios>,
 }

--- a/receiver/src/main.rs
+++ b/receiver/src/main.rs
@@ -35,15 +35,6 @@ async fn run_receiver<T: Server>(args: &cli::Args) -> Result<()> {
 }
 
 fn create_server_config(args: &cli::Args) -> ServerConfig {
-    let mut result = ServerConfig {
-        diallers: Vec::new(),
-        key: args.key.clone(),
-        send_naks: args.nak,
-    };
-
-    if let Some(scenarios) = &args.scenarios {
-        result.diallers = scenarios.diallers.clone();
-    }
-
-    result
+    let diallers = args.scenarios.as_ref().map(|s| s.diallers.clone()).unwrap_or_default();
+    ServerConfig::new(diallers, args.key.clone(), args.nak)
 }

--- a/receiver/src/server/config.rs
+++ b/receiver/src/server/config.rs
@@ -1,0 +1,37 @@
+use common::dc09::parse_dc09_account_name;
+use common::scenarios::DiallerConfig;
+use std::collections::HashMap;
+
+pub type DiallerKeys = HashMap<String, Option<String>>;
+
+/// Server configuration.
+pub struct ServerConfig {
+    pub diallers: DiallerKeys,
+    pub key: Option<String>,
+    pub send_naks: bool,
+}
+
+impl ServerConfig {
+    /// Creates new [`ServerConfig`] instance.
+    pub fn new(diallers: Vec<DiallerConfig>, key: Option<String>, send_naks: bool) -> Self {
+        let diallers = diallers.into_iter().map(|d| (d.name, d.key)).collect::<DiallerKeys>();
+        Self {
+            diallers,
+            key,
+            send_naks,
+        }
+    }
+
+    /// Returns key for the specified message.
+    pub fn get_key_for_message(&self, received_message: &str) -> Option<&str> {
+        if !self.diallers.is_empty() {
+            if let Ok(name) = parse_dc09_account_name(received_message) {
+                if self.diallers.contains_key(&name) {
+                    return self.diallers[&name].as_deref();
+                }
+            }
+        }
+
+        self.key.as_deref()
+    }
+}

--- a/receiver/src/server/mod.rs
+++ b/receiver/src/server/mod.rs
@@ -1,0 +1,18 @@
+pub use self::tcp::TcpServer;
+pub use self::udp::UdpServer;
+
+mod tcp;
+mod udp;
+
+use anyhow::Result;
+use tokio::net::ToSocketAddrs;
+
+/// Represents type that can be treated as a server.
+pub trait Server: Sized {
+    /// Creates new [`Server`] instance.  
+    /// **Note** that `key` can be provided to decrypt encrypted DC09 messages.
+    async fn new(address: impl ToSocketAddrs, key: Option<String>, send_naks: bool) -> Result<Self>;
+
+    /// Runs the server.
+    async fn run(&mut self) -> Result<()>;
+}

--- a/receiver/src/server/mod.rs
+++ b/receiver/src/server/mod.rs
@@ -1,19 +1,13 @@
+pub use self::config::ServerConfig;
 pub use self::tcp::TcpServer;
 pub use self::udp::UdpServer;
 
+mod config;
 mod tcp;
 mod udp;
 
 use anyhow::Result;
-use common::scenarios::DiallerConfig;
 use tokio::net::ToSocketAddrs;
-
-/// Server configuration.
-pub struct ServerConfig {
-    pub diallers: Vec<DiallerConfig>,
-    pub key: Option<String>,
-    pub send_naks: bool,
-}
 
 /// Represents type that can be treated as a server.
 pub trait Server: Sized {

--- a/receiver/src/server/mod.rs
+++ b/receiver/src/server/mod.rs
@@ -5,13 +5,21 @@ mod tcp;
 mod udp;
 
 use anyhow::Result;
+use common::scenarios::DiallerConfig;
 use tokio::net::ToSocketAddrs;
+
+/// Server configuration.
+pub struct ServerConfig {
+    pub diallers: Vec<DiallerConfig>,
+    pub key: Option<String>,
+    pub send_naks: bool,
+}
 
 /// Represents type that can be treated as a server.
 pub trait Server: Sized {
     /// Creates new [`Server`] instance.  
     /// **Note** that `key` can be provided to decrypt encrypted DC09 messages.
-    async fn new(address: impl ToSocketAddrs, key: Option<String>, send_naks: bool) -> Result<Self>;
+    async fn new(address: impl ToSocketAddrs, config: ServerConfig) -> Result<Self>;
 
     /// Runs the server.
     async fn run(&mut self) -> Result<()>;

--- a/receiver/src/server/tcp.rs
+++ b/receiver/src/server/tcp.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use common::dc09::{DC09Message, parse_dc09_account_name};
+use common::dc09::DC09Message;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -87,15 +87,7 @@ async fn process_connection(mut socket: TcpStream, addr: SocketAddr, config: Arc
 }
 
 async fn process_message(socket: &mut TcpStream, addr: &SocketAddr, received_message: &str, config: &ServerConfig) -> bool {
-    let mut key = config.key.as_deref();
-    if !config.diallers.is_empty() {
-        if let Ok(name) = parse_dc09_account_name(received_message) {
-            if let Some(index) = config.diallers.iter().position(|d| d.name == name) {
-                key = config.diallers[index].key.as_deref();
-            }
-        }
-    }
-
+    let key = config.get_key_for_message(received_message);
     match DC09Message::try_from(received_message, key) {
         Ok(msg) => {
             log::info!("{} -> {}", addr, received_message.trim());


### PR DESCRIPTION
This PR adds the following features:
- add support (initial) for scenario files in the dialler and receiver applications
- allow distinct keys for different account names